### PR TITLE
Enable fetching default gateway IP

### DIFF
--- a/NetworkInfo.d.ts
+++ b/NetworkInfo.d.ts
@@ -5,5 +5,6 @@ export namespace NetworkInfo {
   function getIPAddress(): Promise<string | null>;
   function getIPV4Address(): Promise<string | null>;
   function getSubnet(): Promise<string | null>;
+  function getGatewayIPAddress(): Promise<string | null>;
   function getFrequency(): Promise<number | null>;
 }

--- a/NetworkInfo.js
+++ b/NetworkInfo.js
@@ -24,6 +24,10 @@ const NetworkInfo = {
     return await RNNetworkInfo.getIPV4Address();
   },
 
+  async getGatewayIPAddress() {
+    return await RNNetworkInfo.getGatewayIPAddress();
+  },
+
   async getSubnet() {
     return await RNNetworkInfo.getSubnet();
   },

--- a/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
+++ b/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
@@ -1,6 +1,7 @@
 package com.pusherman.networkinfo;
 
 import android.content.Context;
+import android.net.DhcpInfo;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.net.wifi.SupplicantState;
@@ -185,6 +186,28 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                     }
                 } catch (Exception e) {
                     promise.resolve("0.0.0.0");
+                }
+            }
+        }).start();
+    }
+
+    @ReactMethod
+    public void getGatewayIPAddress(final Promise promise) throws Exception {
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                    DhcpInfo dhcpInfo = wifi.getDhcpInfo();
+                    int gatewayIPInt = dhcpInfo.gateway;
+                    String gatewayIP = String.format(
+                      "%d.%d.%d.%d",
+                      ((gatewayIPInt) & 0xFF),
+                      ((gatewayIPInt >> 8 ) & 0xFF),
+                      ((gatewayIPInt >> 16) & 0xFF),
+                      ((gatewayIPInt >> 24) & 0xFF)
+                    );
+                    promise.resolve(gatewayIP);
+                } catch (Exception e) {
+                    promise.resolve(null);
                 }
             }
         }).start();

--- a/ios/RNNetworkInfo.m
+++ b/ios/RNNetworkInfo.m
@@ -153,13 +153,13 @@ RCT_EXPORT_METHOD(getGatewayIPAddress:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     @try{
-	NSString *ipString = nil;
-	struct in_addr gatewayaddr;
-	int r = getdefaultgateway(&(gatewayaddr.s_addr));
-	if(r >= 0) {
-        	ipString = [NSString stringWithFormat: @"%s",inet_ntoa(gatewayaddr)];
+        NSString *ipString = nil;
+        struct in_addr gatewayaddr;
+        int r = getdefaultgateway(&(gatewayaddr.s_addr));
+        if(r >= 0) {
+            ipString = [NSString stringWithFormat: @"%s",inet_ntoa(gatewayaddr)];
     	}
-        resolve(gatewayaddr);
+        resolve(ipString);
     }@catch (NSException *exception) {
         resolve(NULL);
     }

--- a/ios/RNNetworkInfo.m
+++ b/ios/RNNetworkInfo.m
@@ -7,6 +7,7 @@
 //
 
 #import "RNNetworkInfo.h"
+#import "getgateway.h"
 
 #import <ifaddrs.h>
 #import <arpa/inet.h>
@@ -143,6 +144,22 @@ RCT_EXPORT_METHOD(getIPAddress:(RCTPromiseResolveBlock)resolve
         }
         freeifaddrs(interfaces);
         resolve(address);
+    }@catch (NSException *exception) {
+        resolve(NULL);
+    }
+}
+
+RCT_EXPORT_METHOD(getGatewayIPAddress:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    @try{
+	NSString *ipString = nil;
+	struct in_addr gatewayaddr;
+	int r = getdefaultgateway(&(gatewayaddr.s_addr));
+	if(r >= 0) {
+        	ipString = [NSString stringWithFormat: @"%s",inet_ntoa(gatewayaddr)];
+    	}
+        resolve(gatewayaddr);
     }@catch (NSException *exception) {
         resolve(NULL);
     }

--- a/ios/RNNetworkInfo.xcodeproj/project.pbxproj
+++ b/ios/RNNetworkInfo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		045BEB401B52EA6A0013C1B9 /* RNNetworkInfo.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 045BEB3F1B52EA6A0013C1B9 /* RNNetworkInfo.h */; };
 		045BEB421B52EA6A0013C1B9 /* RNNetworkInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 045BEB411B52EA6A0013C1B9 /* RNNetworkInfo.m */; };
+		32B78637230FB6FA00C6A8CD /* getgateway.c in Sources */ = {isa = PBXBuildFile; fileRef = 32B78634230FB6FA00C6A8CD /* getgateway.c */; };
 		A051C2CC22B1C13E001E1191 /* RNNetworkInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 045BEB411B52EA6A0013C1B9 /* RNNetworkInfo.m */; };
 /* End PBXBuildFile section */
 
@@ -38,6 +39,9 @@
 		045BEB3C1B52EA6A0013C1B9 /* libRNNetworkInfo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNNetworkInfo.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		045BEB3F1B52EA6A0013C1B9 /* RNNetworkInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNetworkInfo.h; sourceTree = "<group>"; };
 		045BEB411B52EA6A0013C1B9 /* RNNetworkInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNetworkInfo.m; sourceTree = "<group>"; };
+		32B78634230FB6FA00C6A8CD /* getgateway.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = getgateway.c; sourceTree = "<group>"; };
+		32B78635230FB6FA00C6A8CD /* getgateway.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = getgateway.h; sourceTree = "<group>"; };
+		32B78636230FB6FA00C6A8CD /* route.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = route.h; sourceTree = "<group>"; };
 		A051C2C322B1C080001E1191 /* libRNNetworkInfo-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libRNNetworkInfo-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -62,6 +66,9 @@
 		045BEB331B52EA6A0013C1B9 = {
 			isa = PBXGroup;
 			children = (
+				32B78634230FB6FA00C6A8CD /* getgateway.c */,
+				32B78635230FB6FA00C6A8CD /* getgateway.h */,
+				32B78636230FB6FA00C6A8CD /* route.h */,
 				045BEB3F1B52EA6A0013C1B9 /* RNNetworkInfo.h */,
 				045BEB411B52EA6A0013C1B9 /* RNNetworkInfo.m */,
 				045BEB3D1B52EA6A0013C1B9 /* Products */,
@@ -158,6 +165,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				045BEB421B52EA6A0013C1B9 /* RNNetworkInfo.m in Sources */,
+				32B78637230FB6FA00C6A8CD /* getgateway.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/getgateway.c
+++ b/ios/getgateway.c
@@ -1,0 +1,85 @@
+//
+//  getgateway.c
+//  
+//  This is pulled directly from https://stackoverflow.com/a/29440193/1120802
+//
+
+#include <stdio.h>
+#include <netinet/in.h>
+#include <stdlib.h>
+#include <sys/sysctl.h>
+#include "getgateway.h"
+
+#include "TargetConditionals.h"
+#if TARGET_IPHONE_SIMULATOR
+#include "route.h"
+#define TypeEN    "en1"
+#else
+#include "route.h"
+#define TypeEN    "en0"
+#endif
+
+#include <net/if.h>
+#include <string.h>
+
+#define CTL_NET         4               /* network, see socket.h */
+
+
+#if defined(BSD) || defined(__APPLE__)
+
+#define ROUNDUP(a) \
+((a) > 0 ? (1 + (((a) - 1) | (sizeof(long) - 1))) : sizeof(long))
+
+int getdefaultgateway(in_addr_t * addr)
+{
+    int mib[] = {CTL_NET, PF_ROUTE, 0, AF_INET,
+        NET_RT_FLAGS, RTF_GATEWAY};
+    size_t l;
+    char * buf, * p;
+    struct rt_msghdr * rt;
+    struct sockaddr * sa;
+    struct sockaddr * sa_tab[RTAX_MAX];
+    int i;
+    int r = -1;
+    if(sysctl(mib, sizeof(mib)/sizeof(int), 0, &l, 0, 0) < 0) {
+        return -1;
+    }
+    if(l>0) {
+        buf = malloc(l);
+        if(sysctl(mib, sizeof(mib)/sizeof(int), buf, &l, 0, 0) < 0) {
+            return -1;
+        }
+        for(p=buf; p<buf+l; p+=rt->rtm_msglen) {
+            rt = (struct rt_msghdr *)p;
+            sa = (struct sockaddr *)(rt + 1);
+            for(i=0; i<RTAX_MAX; i++) {
+                if(rt->rtm_addrs & (1 << i)) {
+                    sa_tab[i] = sa;
+                    sa = (struct sockaddr *)((char *)sa + ROUNDUP(sa->sa_len));
+                } else {
+                    sa_tab[i] = NULL;
+                }
+            }
+            
+            if( ((rt->rtm_addrs & (RTA_DST|RTA_GATEWAY)) == (RTA_DST|RTA_GATEWAY))
+               && sa_tab[RTAX_DST]->sa_family == AF_INET
+               && sa_tab[RTAX_GATEWAY]->sa_family == AF_INET) {
+                
+                
+                if(((struct sockaddr_in *)sa_tab[RTAX_DST])->sin_addr.s_addr == 0) {
+                    char ifName[128];
+                    if_indextoname(rt->rtm_index,ifName);
+                    if(strcmp(TypeEN,ifName)==0){
+                        *addr = ((struct sockaddr_in *)(sa_tab[RTAX_GATEWAY]))->sin_addr.s_addr;
+                        r = 0;
+                    }
+                }
+            }
+        }
+        free(buf);
+    }
+    return r;
+}
+
+
+#endif

--- a/ios/getgateway.h
+++ b/ios/getgateway.h
@@ -1,6 +1,5 @@
 //
 //  getgateway.h
-//  OBDInterface
 //
 //  This is pulled directly from https://stackoverflow.com/a/29440193/1120802
 //

--- a/ios/getgateway.h
+++ b/ios/getgateway.h
@@ -1,0 +1,16 @@
+//
+//  getgateway.h
+//  OBDInterface
+//
+//  This is pulled directly from https://stackoverflow.com/a/29440193/1120802
+//
+
+#ifndef getgateway_h
+#define getgateway_h
+
+#include <stdio.h>
+
+int getdefaultgateway(in_addr_t * addr);
+
+#endif /* getgateway_h */
+

--- a/ios/route.h
+++ b/ios/route.h
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2000-2008 Apple Inc. All rights reserved.
+ * Copyright (c) 2000-2017 Apple Inc. All rights reserved.
  *
  * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
@@ -11,10 +11,10 @@
  * unlawful or unlicensed copies of an Apple operating system, or to
  * circumvent, violate, or enable the circumvention or violation of, any
  * terms of an Apple operating system software license agreement.
- * 
+ *
  * Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
@@ -22,7 +22,7 @@
  * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
  * Please see the License for the specific language governing rights and
  * limitations under the License.
- * 
+ *
  * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
  */
 /*
@@ -62,49 +62,18 @@
  */
 
 #ifndef _NET_ROUTE_H_
-#define _NET_ROUTE_H_
+#define	_NET_ROUTE_H_
 #include <sys/appleapiopts.h>
 #include <stdint.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 
 /*
- * Kernel resident routing tables.
- *
- * The routing tables are initialized when interface addresses
- * are set by making entries for all directly connected interfaces.
- */
-
-/*
- * A route consists of a destination address and a reference
- * to a routing entry.  These are often held by protocols
- * in their control blocks, e.g. inpcb.
- */
-#ifdef PRIVATE
-struct  rtentry;
-struct route {
-	/*
-	 * N.B: struct route must begin with ro_rt and ro_flags
-	 * because the code does some casts of a 'struct route_in6 *'
-	 * to a 'struct route *'.
-	 */
-	struct rtentry	*ro_rt;
-	uint32_t	ro_flags;	/* route flags (see below) */
-	struct sockaddr	ro_dst;
-};
-
-#define	ROF_SRCIF_SELECTED	0x1 /* source interface was selected */
-
-#else
-struct route;
-#endif /* PRIVATE */
-
-/*
  * These numbers are used by reliable protocols for determining
  * retransmission behavior and are included in the routing structure.
  */
 struct rt_metrics {
-	u_int32_t	rmx_locks;	/* Kernel must leave these values alone */
+	u_int32_t	rmx_locks;	/* Kernel leaves these values alone */
 	u_int32_t	rmx_mtu;	/* MTU for this path */
 	u_int32_t	rmx_hopcount;	/* max hops expected */
 	int32_t		rmx_expire;	/* lifetime for route, e.g. redirect */
@@ -114,13 +83,103 @@ struct rt_metrics {
 	u_int32_t	rmx_rtt;	/* estimated round trip time */
 	u_int32_t	rmx_rttvar;	/* estimated rtt variance */
 	u_int32_t	rmx_pksent;	/* packets sent using this route */
-	u_int32_t	rmx_filler[4];	/* will be used for T/TCP later */
+	u_int32_t	rmx_state;	/* route state */
+	u_int32_t	rmx_filler[3];	/* will be used for T/TCP later */
 };
 
 /*
  * rmx_rtt and rmx_rttvar are stored as microseconds;
  */
 #define	RTM_RTTUNIT	1000000	/* units for rtt, rttvar, as units per sec */
+
+#ifdef PRIVATE
+struct route_old {
+	void		*ro_rt;
+	uint32_t	ro_flags;
+	struct sockaddr	ro_dst;
+};
+#endif /* PRIVATE */
+
+#ifdef BSD_KERNEL_PRIVATE
+#include <kern/locks.h>
+#include <net/radix.h>
+#include <net/if_llatbl.h>
+#include <sys/eventhandler.h>
+#include <net/if_dl.h>
+
+/*
+ * Kernel resident routing tables.
+ *
+ * The routing tables are initialized when interface addresses
+ * are set by making entries for all directly connected interfaces.
+ */
+
+/* forward declarations */
+struct ifnet_llreach_info;
+struct rt_reach_info;
+
+/*
+ * IP route structure
+ *
+ * A route consists of a destination address and a reference
+ * to a routing entry.  These are often held by protocols
+ * in their control blocks, e.g. inpcb.
+ */
+struct route {
+	/*
+	 * N.B: struct route must begin with ro_{rt, lle, srcia, flags}
+	 * because the code does some casts of a 'struct route_in6 *'
+	 * to a 'struct route *'.
+	 */
+	struct rtentry	*ro_rt;
+	struct llentry	*ro_lle;
+
+	struct ifaddr	*ro_srcia;
+	uint32_t	ro_flags;	/* route flags (see below) */
+	struct sockaddr	ro_dst;
+};
+
+#define	ROF_SRCIF_SELECTED	0x0001  /* source interface was selected */
+#if 0
+/* XXX These will be used in the changes coming in later */
+#define        ROF_NORTREF             0x0002  /* doesn't hold reference on ro_rt */
+#define        ROF_L2_ME               0x0004  /* dst L2 addr is our address */
+#define        ROF_MAY_LOOP            0x0008  /* dst may require loop copy */
+#define        ROF_HAS_HEADER          0x0010  /* mbuf already have its header prepended */
+#define        ROF_REJECT              0x0020  /* Destination is reject */
+#define        ROF_BLACKHOLE           0x0040  /* Destination is blackhole */
+#define        ROF_HAS_GW              0x0080  /* Destination has GW  */
+#endif
+#define	ROF_LLE_CACHE	0x0100  /* Cache link layer  */
+
+#define	ROUTE_UNUSABLE(_ro)						\
+	((_ro)->ro_rt == NULL ||					\
+	((_ro)->ro_rt->rt_flags & (RTF_UP|RTF_CONDEMNED)) != RTF_UP ||	\
+	RT_GENID_OUTOFSYNC((_ro)->ro_rt))
+
+#define	_ROUTE_RELEASE_COMMON(_ro, _rnh_locked) do {			\
+	if ((_ro)->ro_rt != NULL) {					\
+		RT_LOCK_ASSERT_NOTHELD((_ro)->ro_rt);			\
+		if (_rnh_locked)					\
+			rtfree_locked((_ro)->ro_rt);			\
+		else							\
+			rtfree((_ro)->ro_rt);				\
+		(_ro)->ro_rt = NULL;					\
+	}								\
+	if ((_ro)->ro_srcia != NULL) {					\
+		IFA_REMREF((_ro)->ro_srcia);				\
+		(_ro)->ro_srcia = NULL;					\
+		(_ro)->ro_flags &= ~ROF_SRCIF_SELECTED;			\
+	}								\
+	if ((_ro)->ro_lle != NULL) {					\
+		LLE_REMREF((_ro)->ro_lle);				\
+		(_ro)->ro_lle = NULL;					\
+		(_ro)->ro_flags &= ~ROF_LLE_CACHE;			\
+	}								\
+} while (0)
+
+#define	ROUTE_RELEASE_LOCKED(_ro)	_ROUTE_RELEASE_COMMON(_ro, TRUE)
+#define	ROUTE_RELEASE(_ro)		_ROUTE_RELEASE_COMMON(_ro, FALSE)
 
 /*
  * We distinguish between routes to hosts and routes to networks,
@@ -130,40 +189,96 @@ struct rt_metrics {
  * gateways are marked so that the output routines know to address the
  * gateway rather than the ultimate destination.
  */
-#ifdef KERNEL_PRIVATE
-#include <kern/locks.h>
-#ifndef RNF_NORMAL
-#include <net/radix.h>
-#endif
+
+#define	NRTT_HIST	10
 /*
- * Kernel routing entry structure (private).
+ * Kernel routing entry structure.
  */
 struct rtentry {
 	struct	radix_node rt_nodes[2];	/* tree glue, and other values */
-#define	rt_key(r)	((struct sockaddr *)((r)->rt_nodes->rn_key))
-#define	rt_mask(r)	((struct sockaddr *)((r)->rt_nodes->rn_mask))
-	struct	sockaddr *rt_gateway;	/* value */
-	int32_t	rt_refcnt;		/* # held references */
-	uint32_t rt_flags;		/* up/down?, host/net */
-	struct	ifnet *rt_ifp;		/* the answer: interface to use */
-	struct	ifaddr *rt_ifa;		/* the answer: interface addr to use */
-	struct	sockaddr *rt_genmask;	/* for generation of cloned routes */
-	void	*rt_llinfo;		/* pointer to link level info cache */
-	void	(*rt_llinfo_free)(void *); /* link level info free function */
-	struct	rt_metrics rt_rmx;	/* metrics used by rx'ing protocols */
-	struct	rtentry *rt_gwroute;	/* implied entry for gatewayed routes */
-	struct	rtentry *rt_parent;	/* cloning parent of this route */
-	uint32_t generation_id;		/* route generation id */
+#define	rt_key(r)	(SA((r)->rt_nodes->rn_key))
+#define	rt_mask(r)	(SA((r)->rt_nodes->rn_mask))
 	/*
 	 * See bsd/net/route.c for synchronization notes.
 	 */
 	decl_lck_mtx_data(, rt_lock);	/* lock for routing entry */
-};
-#endif /* KERNEL_PRIVATE */
+	uint32_t rt_refcnt;		/* # held references */
+	uint32_t rt_flags;		/* up/down?, host/net */
+	uint32_t rt_genid;		/* route generation id */
+	struct sockaddr *rt_gateway;	/* value */
+	struct ifnet *rt_ifp;		/* the answer: interface to use */
+	struct ifaddr *rt_ifa;		/* the answer: interface addr to use */
+	struct sockaddr *rt_genmask;	/* for generation of cloned routes */
+	void *rt_llinfo;		/* pointer to link level info cache */
+	void (*rt_llinfo_get_ri)	/* llinfo get reachability info fn */
+	    (struct rtentry *, struct rt_reach_info *);
+	void (*rt_llinfo_get_iflri)	/* ifnet llinfo get reach. info fn */
+	    (struct rtentry *, struct ifnet_llreach_info *);
+	void (*rt_llinfo_purge)(struct rtentry *); /* llinfo purge fn */
+	void (*rt_llinfo_free)(void *); /* link level info free function */
+	void (*rt_llinfo_refresh) (struct rtentry *); /* expedite llinfo refresh */
+	struct rt_metrics rt_rmx;	/* metrics used by rx'ing protocols */
+#define	rt_use rt_rmx.rmx_pksent
+	struct rtentry *rt_gwroute;	/* implied entry for gatewayed routes */
+	struct rtentry *rt_parent;	/* cloning parent of this route */
+	struct nstat_counts *rt_stats;	/* route stats */
+	void (*rt_if_ref_fn)(struct ifnet *, int); /* interface ref func */
 
-#ifdef KERNEL_PRIVATE
-#define rt_use rt_rmx.rmx_pksent
-#endif /* KERNEL_PRIVATE */
+	uint32_t *rt_tree_genid;	/* ptr to per-tree route_genid */
+	uint64_t rt_expire;		/* expiration time in uptime seconds */
+	uint64_t base_calendartime;	/* calendar time upon entry creation */
+	uint64_t base_uptime;		/* uptime upon entry creation */
+	u_int32_t rtt_hist[NRTT_HIST];	/* RTT history sample by TCP connections */
+	u_int32_t rtt_min;		/* minimum RTT computed from history */
+	u_int32_t rtt_expire_ts;	/* RTT history expire timestamp */
+	u_int8_t rtt_index;		/* Index into RTT history */
+	/* Event handler context for the rtentrt */
+	struct eventhandler_lists_ctxt rt_evhdlr_ctxt;
+};
+
+enum {
+	ROUTE_STATUS_UPDATE = 1,
+	ROUTE_ENTRY_REFRESH,
+	ROUTE_ENTRY_DELETED,
+	ROUTE_LLENTRY_RESOLVED,
+	ROUTE_LLENTRY_UNREACH,
+	ROUTE_LLENTRY_CHANGED,
+	ROUTE_LLENTRY_STALE,
+	ROUTE_LLENTRY_TIMEDOUT,
+	ROUTE_LLENTRY_DELETED,
+	ROUTE_LLENTRY_EXPIRED,
+	ROUTE_LLENTRY_PROBED,
+	ROUTE_EVHDLR_DEREGISTER,
+};
+
+extern const char * route_event2str(int route_event);
+
+typedef void (*route_event_fn) (struct eventhandler_entry_arg,
+    struct sockaddr *, int, struct sockaddr *, int);
+EVENTHANDLER_DECLARE(route_event, route_event_fn);
+
+/*
+ * Synchronize route entry's generation ID with the tree's.
+ */
+#define	RT_GENID_SYNC(_rt) do {						\
+	if ((_rt)->rt_tree_genid != NULL)				\
+		(_rt)->rt_genid = *(_rt)->rt_tree_genid;		\
+} while (0)
+
+/*
+ * Indicates whether or not the route entry's generation ID is stale.
+ */
+#define	RT_GENID_OUTOFSYNC(_rt)						\
+	((_rt)->rt_tree_genid != NULL &&				\
+	*(_rt)->rt_tree_genid != (_rt)->rt_genid)
+
+enum {
+	ROUTE_OP_READ,
+	ROUTE_OP_WRITE,
+};
+
+extern int route_op_entitlement_check(struct socket *, kauth_cred_t, int, boolean_t);
+#endif /* BSD_KERNEL_PRIVATE */
 
 #define	RTF_UP		0x1		/* route usable */
 #define	RTF_GATEWAY	0x2		/* destination is a gateway */
@@ -171,28 +286,45 @@ struct rtentry {
 #define	RTF_REJECT	0x8		/* host or net unreachable */
 #define	RTF_DYNAMIC	0x10		/* created dynamically (by redirect) */
 #define	RTF_MODIFIED	0x20		/* modified dynamically (by redirect) */
-#define RTF_DONE	0x40		/* message confirmed */
-#define RTF_DELCLONE	0x80		/* delete cloned route */
-#define RTF_CLONING	0x100		/* generate new routes on use */
-#define RTF_XRESOLVE	0x200		/* external daemon resolves name */
-#define RTF_LLINFO	0x400		/* generated by link layer (e.g. ARP) */
-#define RTF_STATIC	0x800		/* manually added */
-#define RTF_BLACKHOLE	0x1000		/* just discard pkts (during updates) */
-#define RTF_PROTO2	0x4000		/* protocol specific routing flag */
-#define RTF_PROTO1	0x8000		/* protocol specific routing flag */
+#define	RTF_DONE	0x40		/* message confirmed */
+#define	RTF_DELCLONE	0x80		/* delete cloned route */
+#define	RTF_CLONING	0x100		/* generate new routes on use */
+#define	RTF_XRESOLVE	0x200		/* external daemon resolves name */
+#define	RTF_LLINFO	0x400		/* DEPRECATED - exists ONLY for backward
+					   compatibility */
+#define	RTF_LLDATA	0x400		/* used by apps to add/del L2 entries */
+#define	RTF_STATIC	0x800		/* manually added */
+#define	RTF_BLACKHOLE	0x1000		/* just discard pkts (during updates) */
+#define	RTF_NOIFREF	0x2000		/* not eligible for RTF_IFREF */
+#define	RTF_PROTO2	0x4000		/* protocol specific routing flag */
+#define	RTF_PROTO1	0x8000		/* protocol specific routing flag */
 
-#define RTF_PRCLONING	0x10000		/* protocol requires cloning */
-#define RTF_WASCLONED	0x20000		/* route generated through cloning */
-#define RTF_PROTO3	0x40000		/* protocol specific routing flag */
-					/* 0x80000 unused */
-#define RTF_PINNED	0x100000	/* future use */
+#define	RTF_PRCLONING	0x10000		/* protocol requires cloning */
+#define	RTF_WASCLONED	0x20000		/* route generated through cloning */
+#define	RTF_PROTO3	0x40000		/* protocol specific routing flag */
+/* 0x80000 unused */
+#define	RTF_PINNED	0x100000	/* future use */
 #define	RTF_LOCAL	0x200000	/* route represents a local address */
 #define	RTF_BROADCAST	0x400000	/* route represents a bcast address */
 #define	RTF_MULTICAST	0x800000	/* route represents a mcast address */
-#define RTF_IFSCOPE	0x1000000	/* has valid interface scope */
-#define RTF_CONDEMNED	0x2000000	/* defunct; no longer modifiable */
-					/* 0x4000000 and up unassigned */
+#define	RTF_IFSCOPE	0x1000000	/* has valid interface scope */
+#define	RTF_CONDEMNED	0x2000000	/* defunct; no longer modifiable */
+#define	RTF_IFREF	0x4000000	/* route holds a ref to interface */
+#define	RTF_PROXY	0x8000000	/* proxying, no interface scope */
+#define	RTF_ROUTER	0x10000000	/* host is a router */
+#define RTF_DEAD	0x20000000	/* Route entry is being freed */
+/* 0x40000000 and up unassigned */
 
+#define	RTPRF_OURS	RTF_PROTO3	/* set on routes we manage */
+#define	RTF_BITS \
+	"\020\1UP\2GATEWAY\3HOST\4REJECT\5DYNAMIC\6MODIFIED\7DONE" \
+	"\10DELCLONE\11CLONING\12XRESOLVE\13LLINFO\14STATIC\15BLACKHOLE" \
+	"\16NOIFREF\17PROTO2\20PROTO1\21PRCLONING\22WASCLONED\23PROTO3" \
+	"\25PINNED\26LOCAL\27BROADCAST\30MULTICAST\31IFSCOPE\32CONDEMNED" \
+	"\33IFREF\34PROXY\35ROUTER"
+
+#define	IS_DIRECT_HOSTROUTE(rt)	\
+	(((rt)->rt_flags & (RTF_HOST | RTF_GATEWAY)) == RTF_HOST)
 /*
  * Routing statistics.
  */
@@ -202,119 +334,157 @@ struct	rtstat {
 	short	rts_newgateway;		/* routes modified by redirects */
 	short	rts_unreach;		/* lookups which failed */
 	short	rts_wildcard;		/* lookups satisfied by a wildcard */
+	short	rts_badrtgwroute;	/* route to gateway is not direct */
 };
 
 /*
  * Structures for routing messages.
  */
 struct rt_msghdr {
-	u_short	rtm_msglen;		/* to skip over non-understood messages */
-	u_char	rtm_version;		/* future binary compatibility */
-	u_char	rtm_type;		/* message type */
-	u_short	rtm_index;		/* index for associated ifp */
-	int	rtm_flags;		/* flags, incl. kern & message, e.g. DONE */
-	int	rtm_addrs;		/* bitmask identifying sockaddrs in msg */
-	pid_t	rtm_pid;		/* identify sender */
-	int	rtm_seq;		/* for sender to identify action */
-	int	rtm_errno;		/* why failed */
-	int	rtm_use;		/* from rtentry */
-	u_int32_t rtm_inits;		/* which metrics we are initializing */
-	struct rt_metrics rtm_rmx;	/* metrics themselves */
+	u_short	rtm_msglen;	/* to skip over non-understood messages */
+	u_char	rtm_version;	/* future binary compatibility */
+	u_char	rtm_type;	/* message type */
+	u_short	rtm_index;	/* index for associated ifp */
+	int	rtm_flags;	/* flags, incl. kern & message, e.g. DONE */
+	int	rtm_addrs;	/* bitmask identifying sockaddrs in msg */
+	pid_t	rtm_pid;	/* identify sender */
+	int	rtm_seq;	/* for sender to identify action */
+	int	rtm_errno;	/* why failed */
+	int	rtm_use;	/* from rtentry */
+	u_int32_t rtm_inits;	/* which metrics we are initializing */
+	struct rt_metrics rtm_rmx; /* metrics themselves */
 };
 
 struct rt_msghdr2 {
-	u_short	rtm_msglen;		/* to skip over non-understood messages */
-	u_char	rtm_version;		/* future binary compatibility */
-	u_char	rtm_type;		/* message type */
-	u_short	rtm_index;		/* index for associated ifp */
-	int	rtm_flags;		/* flags, incl. kern & message, e.g. DONE */
-	int	rtm_addrs;		/* bitmask identifying sockaddrs in msg */
-	int32_t	rtm_refcnt;		/* reference count */
-	int	rtm_parentflags;	/* flags of the parent route */
-	int	rtm_reserved;		/* reserved field set to 0 */
-	int	rtm_use;		/* from rtentry */
-	u_int32_t rtm_inits;		/* which metrics we are initializing */
-	struct rt_metrics rtm_rmx;	/* metrics themselves */
+	u_short	rtm_msglen;	/* to skip over non-understood messages */
+	u_char	rtm_version;	/* future binary compatibility */
+	u_char	rtm_type;	/* message type */
+	u_short	rtm_index;	/* index for associated ifp */
+	int	rtm_flags;	/* flags, incl. kern & message, e.g. DONE */
+	int	rtm_addrs;	/* bitmask identifying sockaddrs in msg */
+	int32_t	rtm_refcnt;	/* reference count */
+	int	rtm_parentflags; /* flags of the parent route */
+	int	rtm_reserved;	/* reserved field set to 0 */
+	int	rtm_use;	/* from rtentry */
+	u_int32_t rtm_inits;	/* which metrics we are initializing */
+	struct rt_metrics rtm_rmx; /* metrics themselves */
 };
 
+#ifdef PRIVATE
+struct kev_netevent_apnfallbk_data {
+	pid_t           epid;           /* effective PID */
+	uuid_t          euuid;          /* effective UUID */
+};
 
-#define RTM_VERSION	5	/* Up the ante and ignore older versions */
+/*
+ * Route reachability info.
+ */
+struct rt_reach_info {
+	u_int32_t	ri_refcnt;	/* reference count */
+	u_int32_t	ri_probes;	/* total # of probes */
+	u_int64_t	ri_snd_expire;	/* tx expiration (calendar) time */
+	u_int64_t	ri_rcv_expire;	/* rx expiration (calendar) time */
+	int32_t		ri_rssi;	/* received signal strength */
+	int32_t		ri_lqm;		/* link quality metric */
+	int32_t		ri_npm;		/* node proximity metric */
+};
+
+/*
+ * Extended routing message header (private).
+ */
+struct rt_msghdr_ext {
+	u_short	rtm_msglen;	/* to skip over non-understood messages */
+	u_char	rtm_version;	/* future binary compatibility */
+	u_char	rtm_type;	/* message type */
+	u_int32_t rtm_index;	/* index for associated ifp */
+	u_int32_t rtm_flags;	/* flags, incl. kern & message, e.g. DONE */
+	u_int32_t rtm_reserved;	/* for future use */
+	u_int32_t rtm_addrs;	/* bitmask identifying sockaddrs in msg */
+	pid_t	rtm_pid;	/* identify sender */
+	int	rtm_seq;	/* for sender to identify action */
+	int	rtm_errno;	/* why failed */
+	u_int32_t rtm_use;	/* from rtentry */
+	u_int32_t rtm_inits;	/* which metrics we are initializing */
+	struct rt_metrics rtm_rmx;	/* metrics themselves */
+	struct rt_reach_info rtm_ri;	/* route reachability info */
+};
+#endif /* PRIVATE */
+
+#define	RTM_VERSION	5	/* Up the ante and ignore older versions */
 
 /*
  * Message types.
  */
-#define RTM_ADD		0x1	/* Add Route */
-#define RTM_DELETE	0x2	/* Delete Route */
-#define RTM_CHANGE	0x3	/* Change Metrics or flags */
-#define RTM_GET		0x4	/* Report Metrics */
-#define RTM_LOSING	0x5	/* Kernel Suspects Partitioning */
-#define RTM_REDIRECT	0x6	/* Told to use different route */
-#define RTM_MISS	0x7	/* Lookup failed on this address */
-#define RTM_LOCK	0x8	/* fix specified metrics */
-#define RTM_OLDADD	0x9	/* caused by SIOCADDRT */
-#define RTM_OLDDEL	0xa	/* caused by SIOCDELRT */
-#define RTM_RESOLVE	0xb	/* req to resolve dst to LL addr */
-#define RTM_NEWADDR	0xc	/* address being added to iface */
-#define RTM_DELADDR	0xd	/* address being removed from iface */
-#define RTM_IFINFO	0xe	/* iface going up/down etc. */
+#define	RTM_ADD		0x1	/* Add Route */
+#define	RTM_DELETE	0x2	/* Delete Route */
+#define	RTM_CHANGE	0x3	/* Change Metrics or flags */
+#define	RTM_GET		0x4	/* Report Metrics */
+#define	RTM_LOSING	0x5	/* RTM_LOSING is no longer generated by xnu
+				   and is deprecated */
+#define	RTM_REDIRECT	0x6	/* Told to use different route */
+#define	RTM_MISS	0x7	/* Lookup failed on this address */
+#define	RTM_LOCK	0x8	/* fix specified metrics */
+#define	RTM_OLDADD	0x9	/* caused by SIOCADDRT */
+#define	RTM_OLDDEL	0xa	/* caused by SIOCDELRT */
+#define	RTM_RESOLVE	0xb	/* req to resolve dst to LL addr */
+#define	RTM_NEWADDR	0xc	/* address being added to iface */
+#define	RTM_DELADDR	0xd	/* address being removed from iface */
+#define	RTM_IFINFO	0xe	/* iface going up/down etc. */
 #define	RTM_NEWMADDR	0xf	/* mcast group membership being added to if */
 #define	RTM_DELMADDR	0x10	/* mcast group membership being deleted */
 #ifdef PRIVATE
-#define RTM_GET_SILENT	0x11
+#define	RTM_GET_SILENT	0x11
 #endif /* PRIVATE */
-#define RTM_IFINFO2	0x12	/* */
-#define RTM_NEWMADDR2	0x13	/* */
-#define RTM_GET2	0x14	/* */
+#define	RTM_IFINFO2	0x12	/* */
+#define	RTM_NEWMADDR2	0x13	/* */
+#define	RTM_GET2	0x14	/* */
+#ifdef PRIVATE
+#define	RTM_GET_EXT	0x15
+#endif /* PRIVATE */
 
 /*
  * Bitmask values for rtm_inits and rmx_locks.
  */
-#define RTV_MTU		0x1	/* init or lock _mtu */
-#define RTV_HOPCOUNT	0x2	/* init or lock _hopcount */
-#define RTV_EXPIRE	0x4	/* init or lock _expire */
-#define RTV_RPIPE	0x8	/* init or lock _recvpipe */
-#define RTV_SPIPE	0x10	/* init or lock _sendpipe */
-#define RTV_SSTHRESH	0x20	/* init or lock _ssthresh */
-#define RTV_RTT		0x40	/* init or lock _rtt */
-#define RTV_RTTVAR	0x80	/* init or lock _rttvar */
+#define	RTV_MTU		0x1	/* init or lock _mtu */
+#define	RTV_HOPCOUNT	0x2	/* init or lock _hopcount */
+#define	RTV_EXPIRE	0x4	/* init or lock _expire */
+#define	RTV_RPIPE	0x8	/* init or lock _recvpipe */
+#define	RTV_SPIPE	0x10	/* init or lock _sendpipe */
+#define	RTV_SSTHRESH	0x20	/* init or lock _ssthresh */
+#define	RTV_RTT		0x40	/* init or lock _rtt */
+#define	RTV_RTTVAR	0x80	/* init or lock _rttvar */
+#ifdef PRIVATE
+#define	RTV_REFRESH_HOST	0x100	/* init host route to expedite refresh */
+#endif
 
 /*
  * Bitmask values for rtm_addrs.
  */
-#define RTA_DST		0x1	/* destination sockaddr present */
-#define RTA_GATEWAY	0x2	/* gateway sockaddr present */
-#define RTA_NETMASK	0x4	/* netmask sockaddr present */
-#define RTA_GENMASK	0x8	/* cloning mask sockaddr present */
-#define RTA_IFP		0x10	/* interface name sockaddr present */
-#define RTA_IFA		0x20	/* interface addr sockaddr present */
-#define RTA_AUTHOR	0x40	/* sockaddr for author of redirect */
-#define RTA_BRD		0x80	/* for NEWADDR, broadcast or p-p dest addr */
+#define	RTA_DST		0x1	/* destination sockaddr present */
+#define	RTA_GATEWAY	0x2	/* gateway sockaddr present */
+#define	RTA_NETMASK	0x4	/* netmask sockaddr present */
+#define	RTA_GENMASK	0x8	/* cloning mask sockaddr present */
+#define	RTA_IFP		0x10	/* interface name sockaddr present */
+#define	RTA_IFA		0x20	/* interface addr sockaddr present */
+#define	RTA_AUTHOR	0x40	/* sockaddr for author of redirect */
+#define	RTA_BRD		0x80	/* for NEWADDR, broadcast or p-p dest addr */
 
 /*
  * Index offsets for sockaddr array for alternate internal encoding.
  */
-#define RTAX_DST	0	/* destination sockaddr present */
-#define RTAX_GATEWAY	1	/* gateway sockaddr present */
-#define RTAX_NETMASK	2	/* netmask sockaddr present */
-#define RTAX_GENMASK	3	/* cloning mask sockaddr present */
-#define RTAX_IFP	4	/* interface name sockaddr present */
-#define RTAX_IFA	5	/* interface addr sockaddr present */
-#define RTAX_AUTHOR	6	/* sockaddr for author of redirect */
-#define RTAX_BRD	7	/* for NEWADDR, broadcast or p-p dest addr */
-#define RTAX_MAX	8	/* size of array to allocate */
+#define	RTAX_DST	0	/* destination sockaddr present */
+#define	RTAX_GATEWAY	1	/* gateway sockaddr present */
+#define	RTAX_NETMASK	2	/* netmask sockaddr present */
+#define	RTAX_GENMASK	3	/* cloning mask sockaddr present */
+#define	RTAX_IFP	4	/* interface name sockaddr present */
+#define	RTAX_IFA	5	/* interface addr sockaddr present */
+#define	RTAX_AUTHOR	6	/* sockaddr for author of redirect */
+#define	RTAX_BRD	7	/* for NEWADDR, broadcast or p-p dest addr */
+#define	RTAX_MAX	8	/* size of array to allocate */
 
 struct rt_addrinfo {
 	int	rti_addrs;
 	struct	sockaddr *rti_info[RTAX_MAX];
-};
-
-struct route_cb {
-	int	ip_count;
-	int	ip6_count;
-	int	ipx_count;
-	int	ns_count;
-	int	iso_count;
-	int	any_count;
 };
 
 #ifdef PRIVATE
@@ -324,7 +494,7 @@ struct route_cb {
 #define	IFSCOPE_NONE	0
 #endif /* PRIVATE */
 
-#ifdef KERNEL_PRIVATE
+#ifdef BSD_KERNEL_PRIVATE
 /*
  * Generic call trace used by some subsystems (e.g. route, ifaddr)
  */
@@ -338,23 +508,17 @@ typedef struct ctrace {
 extern void ctrace_record(ctrace_t *);
 
 #define	RT_LOCK_ASSERT_HELD(_rt)					\
-	lck_mtx_assert(&(_rt)->rt_lock, LCK_MTX_ASSERT_OWNED)
+	LCK_MTX_ASSERT(&(_rt)->rt_lock, LCK_MTX_ASSERT_OWNED)
 
 #define	RT_LOCK_ASSERT_NOTHELD(_rt)					\
-	lck_mtx_assert(&(_rt)->rt_lock, LCK_MTX_ASSERT_NOTOWNED)
+	LCK_MTX_ASSERT(&(_rt)->rt_lock, LCK_MTX_ASSERT_NOTOWNED)
 
 #define	RT_LOCK(_rt) do {						\
-	if (!rte_debug)							\
-		lck_mtx_lock(&(_rt)->rt_lock);				\
-	else								\
-		rt_lock(_rt, FALSE);					\
+	rt_lock(_rt, FALSE);						\
 } while (0)
 
 #define	RT_LOCK_SPIN(_rt) do {						\
-	if (!rte_debug)							\
-		lck_mtx_lock_spin(&(_rt)->rt_lock);			\
-	else								\
-		rt_lock(_rt, TRUE);					\
+	rt_lock(_rt, TRUE);						\
 } while (0)
 
 #define	RT_CONVERT_LOCK(_rt) do {					\
@@ -363,20 +527,11 @@ extern void ctrace_record(ctrace_t *);
 } while (0)
 
 #define	RT_UNLOCK(_rt) do {						\
-	if (!rte_debug)							\
-		lck_mtx_unlock(&(_rt)->rt_lock);			\
-	else								\
-		rt_unlock(_rt);						\
+	rt_unlock(_rt);							\
 } while (0)
 
 #define	RT_ADDREF_LOCKED(_rt) do {					\
-	if (!rte_debug) {						\
-		RT_LOCK_ASSERT_HELD(_rt);				\
-		if (++(_rt)->rt_refcnt == 0)				\
-			panic("RT_ADDREF(%p) bad refcnt\n", _rt);	\
-	} else {							\
-		rtref(_rt);						\
-	}								\
+	rtref(_rt);							\
 } while (0)
 
 /*
@@ -390,14 +545,7 @@ extern void ctrace_record(ctrace_t *);
 } while (0)
 
 #define	RT_REMREF_LOCKED(_rt) do {					\
-	if (!rte_debug) {						\
-		RT_LOCK_ASSERT_HELD(_rt);				\
-		if ((_rt)->rt_refcnt == 0)				\
-			panic("RT_REMREF(%p) bad refcnt\n", _rt);	\
-		--(_rt)->rt_refcnt;					\
-	} else {							\
-		(void) rtunref(_rt);					\
-	}								\
+	(void) rtunref(_rt);						\
 } while (0)
 
 /*
@@ -410,45 +558,56 @@ extern void ctrace_record(ctrace_t *);
 	RT_UNLOCK(_rt);							\
 } while (0)
 
-#define RTFREE(_rt)		rtfree(_rt)
-#define RTFREE_LOCKED(_rt)	rtfree_locked(_rt)
+/*
+ * This macro calculates skew in wall clock, just in case the user changes the
+ * system time. This skew adjustment is required because we now keep the
+ * expiration times in uptime terms in the kernel, but the userland still
+ * expects expiration times in terms of calendar times.  This is used when
+ * reporting rt_expire, ln_expire, etc. values to user space.
+ */
+#define	NET_CALCULATE_CLOCKSKEW(cc, ic, cu, iu)				\
+	((cc.tv_sec - ic) - (cu - iu))
 
-extern struct route_cb route_cb;
+extern unsigned int rt_verbose;
 extern struct radix_node_head *rt_tables[AF_MAX+1];
-__private_extern__ lck_mtx_t *rnh_lock;
-__private_extern__ int use_routegenid;
-__private_extern__ uint32_t route_generation;
-__private_extern__ int rttrash;
-__private_extern__ unsigned int rte_debug;
+extern lck_mtx_t *rnh_lock;
+extern uint32_t route_genid_inet;	/* INET route generation count */
+#if INET6
+extern uint32_t route_genid_inet6;	/* INET6 route generation count */
+#endif /* INET6 */
+extern int rttrash;
+extern unsigned int rte_debug;
 
 struct ifmultiaddr;
 struct proc;
 
-extern void route_init(void) __attribute__((section("__TEXT, initcode")));
+extern void route_init(void);
 extern void routegenid_update(void);
+extern void routegenid_inet_update(void);
+extern void routegenid_inet6_update(void);
 extern void rt_ifmsg(struct ifnet *);
 extern void rt_missmsg(int, struct rt_addrinfo *, int, int);
 extern void rt_newaddrmsg(int, struct ifaddr *, int, struct rtentry *);
 extern void rt_newmaddrmsg(int, struct ifmultiaddr *);
 extern int rt_setgate(struct rtentry *, struct sockaddr *, struct sockaddr *);
-extern void set_primary_ifscope(unsigned int);
-extern unsigned int get_primary_ifscope(void);
-extern boolean_t rt_inet_default(struct rtentry *, struct sockaddr *);
+extern void set_primary_ifscope(int, unsigned int);
+extern unsigned int get_primary_ifscope(int);
+extern boolean_t rt_primary_default(struct rtentry *, struct sockaddr *);
 extern struct rtentry *rt_lookup(boolean_t, struct sockaddr *,
     struct sockaddr *, struct radix_node_head *, unsigned int);
+extern struct rtentry *rt_lookup_coarse(boolean_t, struct sockaddr *,
+    struct sockaddr *, struct radix_node_head *);
 extern void rtalloc(struct route *);
+extern void rtalloc_scoped(struct route *, unsigned int);
 extern void rtalloc_ign(struct route *, uint32_t);
-extern void rtalloc_ign_locked(struct route *, uint32_t);
 extern void rtalloc_scoped_ign(struct route *, uint32_t, unsigned int);
-extern void rtalloc_scoped_ign_locked(struct route *, uint32_t, unsigned int);
 extern struct rtentry *rtalloc1(struct sockaddr *, int, uint32_t);
-extern struct rtentry *rtalloc1_locked(struct sockaddr *, int, uint32_t);
 extern struct rtentry *rtalloc1_scoped(struct sockaddr *, int, uint32_t,
     unsigned int);
 extern struct rtentry *rtalloc1_scoped_locked(struct sockaddr *, int,
     uint32_t, unsigned int);
-extern void rtfree(struct rtentry *);
 extern void rtfree_locked(struct rtentry *);
+extern void rtfree(struct rtentry *);
 extern void rtref(struct rtentry *);
 /*
  * rtunref will decrement the refcount, rtfree will decrement and free if
@@ -464,15 +623,65 @@ extern void rtredirect(struct ifnet *, struct sockaddr *, struct sockaddr *,
     struct sockaddr *, int, struct sockaddr *, struct rtentry **);
 extern int rtrequest(int, struct sockaddr *,
     struct sockaddr *, struct sockaddr *, int, struct rtentry **);
+extern int rtrequest_scoped(int, struct sockaddr *, struct sockaddr *,
+    struct sockaddr *, int, struct rtentry **, unsigned int);
 extern int rtrequest_locked(int, struct sockaddr *,
     struct sockaddr *, struct sockaddr *, int, struct rtentry **);
 extern int rtrequest_scoped_locked(int, struct sockaddr *, struct sockaddr *,
     struct sockaddr *, int, struct rtentry **, unsigned int);
-extern unsigned int sa_get_ifscope(struct sockaddr *);
+extern void sin_set_ifscope(struct sockaddr *, unsigned int);
+extern unsigned int sin_get_ifscope(struct sockaddr *);
+extern unsigned int sin6_get_ifscope(struct sockaddr *);
 extern void rt_lock(struct rtentry *, boolean_t);
 extern void rt_unlock(struct rtentry *);
-extern struct sockaddr *rtm_scrub_ifscope(int, struct sockaddr *,
-    struct sockaddr *, struct sockaddr_storage *);
-#endif /* KERNEL_PRIVATE */
+extern struct sockaddr *rtm_scrub(int, int, struct sockaddr *,
+    struct sockaddr *, void *, uint32_t, kauth_cred_t *);
+extern boolean_t rt_validate(struct rtentry *);
+extern void rt_set_proxy(struct rtentry *, boolean_t);
+extern void rt_set_gwroute(struct rtentry *, struct sockaddr *,
+    struct rtentry *);
+extern void rt_revalidate_gwroute(struct rtentry *, struct rtentry *);
+extern errno_t route_to_gwroute(const struct sockaddr *, struct rtentry *,
+    struct rtentry **);
+extern void rt_setexpire(struct rtentry *, uint64_t);
+extern void rt_str(struct rtentry *, char *, uint32_t, char *, uint32_t);
+extern const char *rtm2str(int);
+extern void route_copyin(struct route *, struct route *, size_t);
+extern void route_copyout(struct route *, const struct route *, size_t);
+extern boolean_t rt_ifa_is_dst(struct sockaddr *, struct ifaddr *);
+extern struct sockaddr *sa_copy(struct sockaddr *, struct sockaddr_storage *,
+    unsigned int *);
 
-#endif
+/*
+ * The following is used to enqueue work items for route events
+ * and also used to pass route event while walking the tree
+ */
+struct route_event {
+	struct rtentry *rt;
+	/*
+	 * There's no reference taken on gwrt.
+	 * We only use it to check whether we should
+	 * point to rt_gateway or the embedded rt_addr
+	 * structure.
+	 */
+	struct rtentry *gwrt;
+	union {
+		union sockaddr_in_4_6 _rtev_ipaddr;
+		struct sockaddr_dl _rtev_lladdr;
+		char _rtev_addr_bytes[DLIL_SDLMAXLEN];
+	} rt_addr;
+	uint32_t route_event_code;
+	eventhandler_tag evtag;
+};
+
+#define rtev_ipaddr	rt_addr._rtev_ipaddr
+#define rtev_lladdr	rt_addr._rtev_lladdr
+#define	rtev_addr_bytes	rt_addr._rtev_addr_bytes
+
+extern void route_event_init(struct route_event *p_route_ev, struct rtentry *rt,
+    struct rtentry *gwrt, int route_ev_code);
+extern int route_event_walktree(struct radix_node *rn, void *arg);
+extern void route_event_enqueue_nwk_wq_entry(struct rtentry *, struct rtentry *,
+    uint32_t, eventhandler_tag, boolean_t);
+#endif /* BSD_KERNEL_PRIVATE */
+#endif /* _NET_ROUTE_H_ */

--- a/ios/route.h
+++ b/ios/route.h
@@ -1,0 +1,478 @@
+/*
+ *  * Copyright (c) 2000-2008 Apple Inc. All rights reserved.
+ *   *
+ *    * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *     * 
+ *      * This file contains Original Code and/or Modifications of Original Code
+ *       * as defined in and that are subject to the Apple Public Source License
+ *        * Version 2.0 (the 'License'). You may not use this file except in
+ *         * compliance with the License. The rights granted to you under the License
+ *          * may not be used to create, or enable the creation or redistribution of,
+ *           * unlawful or unlicensed copies of an Apple operating system, or to
+ *            * circumvent, violate, or enable the circumvention or violation of, any
+ *             * terms of an Apple operating system software license agreement.
+ *              * 
+ *               * Please obtain a copy of the License at
+ *                * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *                 * 
+ *                  * The Original Code and all software distributed under the License are
+ *                   * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ *                    * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ *                     * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ *                      * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ *                       * Please see the License for the specific language governing rights and
+ *                        * limitations under the License.
+ *                         * 
+ *                          * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ *                           */
+/*
+ *  * Copyright (c) 1980, 1986, 1993
+ *   *	The Regents of the University of California.  All rights reserved.
+ *    *
+ *     * Redistribution and use in source and binary forms, with or without
+ *      * modification, are permitted provided that the following conditions
+ *       * are met:
+ *        * 1. Redistributions of source code must retain the above copyright
+ *         *    notice, this list of conditions and the following disclaimer.
+ *          * 2. Redistributions in binary form must reproduce the above copyright
+ *           *    notice, this list of conditions and the following disclaimer in the
+ *            *    documentation and/or other materials provided with the distribution.
+ *             * 3. All advertising materials mentioning features or use of this software
+ *              *    must display the following acknowledgement:
+ *               *	This product includes software developed by the University of
+ *                *	California, Berkeley and its contributors.
+ *                 * 4. Neither the name of the University nor the names of its contributors
+ *                  *    may be used to endorse or promote products derived from this software
+ *                   *    without specific prior written permission.
+ *                    *
+ *                     * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ *                      * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *                       * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *                        * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ *                         * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *                          * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *                           * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *                            * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *                             * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *                              * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *                               * SUCH DAMAGE.
+ *                                *
+ *                                 *	@(#)route.h	8.3 (Berkeley) 4/19/94
+ *                                  * $FreeBSD: src/sys/net/route.h,v 1.36.2.1 2000/08/16 06:14:23 jayanth Exp $
+ *                                   */
+
+#ifndef _NET_ROUTE_H_
+#define _NET_ROUTE_H_
+#include <sys/appleapiopts.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+
+/*
+ *  * Kernel resident routing tables.
+ *   *
+ *    * The routing tables are initialized when interface addresses
+ *     * are set by making entries for all directly connected interfaces.
+ *      */
+
+/*
+ *  * A route consists of a destination address and a reference
+ *   * to a routing entry.  These are often held by protocols
+ *    * in their control blocks, e.g. inpcb.
+ *     */
+#ifdef PRIVATE
+struct  rtentry;
+struct route {
+		/*
+		 * 	 * N.B: struct route must begin with ro_rt and ro_flags
+		 * 	 	 * because the code does some casts of a 'struct route_in6 *'
+		 * 	 	 	 * to a 'struct route *'.
+		 * 	 	 	 	 */
+		struct rtentry	*ro_rt;
+			uint32_t	ro_flags;	/* route flags (see below) */
+				struct sockaddr	ro_dst;
+};
+
+#define	ROF_SRCIF_SELECTED	0x1 /* source interface was selected */
+
+#else
+struct route;
+#endif /* PRIVATE */
+
+/*
+ *  * These numbers are used by reliable protocols for determining
+ *   * retransmission behavior and are included in the routing structure.
+ *    */
+struct rt_metrics {
+		u_int32_t	rmx_locks;	/* Kernel must leave these values alone */
+			u_int32_t	rmx_mtu;	/* MTU for this path */
+				u_int32_t	rmx_hopcount;	/* max hops expected */
+					int32_t		rmx_expire;	/* lifetime for route, e.g. redirect */
+						u_int32_t	rmx_recvpipe;	/* inbound delay-bandwidth product */
+							u_int32_t	rmx_sendpipe;	/* outbound delay-bandwidth product */
+								u_int32_t	rmx_ssthresh;	/* outbound gateway buffer limit */
+									u_int32_t	rmx_rtt;	/* estimated round trip time */
+										u_int32_t	rmx_rttvar;	/* estimated rtt variance */
+											u_int32_t	rmx_pksent;	/* packets sent using this route */
+												u_int32_t	rmx_filler[4];	/* will be used for T/TCP later */
+};
+
+/*
+ *  * rmx_rtt and rmx_rttvar are stored as microseconds;
+ *   */
+#define	RTM_RTTUNIT	1000000	/* units for rtt, rttvar, as units per sec */
+
+/*
+ *  * We distinguish between routes to hosts and routes to networks,
+ *   * preferring the former if available.  For each route we infer
+ *    * the interface to use from the gateway address supplied when
+ *     * the route was entered.  Routes that forward packets through
+ *      * gateways are marked so that the output routines know to address the
+ *       * gateway rather than the ultimate destination.
+ *        */
+#ifdef KERNEL_PRIVATE
+#include <kern/locks.h>
+#ifndef RNF_NORMAL
+#include <net/radix.h>
+#endif
+/*
+ *  * Kernel routing entry structure (private).
+ *   */
+struct rtentry {
+		struct	radix_node rt_nodes[2];	/* tree glue, and other values */
+#define	rt_key(r)	((struct sockaddr *)((r)->rt_nodes->rn_key))
+#define	rt_mask(r)	((struct sockaddr *)((r)->rt_nodes->rn_mask))
+			struct	sockaddr *rt_gateway;	/* value */
+				int32_t	rt_refcnt;		/* # held references */
+					uint32_t rt_flags;		/* up/down?, host/net */
+						struct	ifnet *rt_ifp;		/* the answer: interface to use */
+							struct	ifaddr *rt_ifa;		/* the answer: interface addr to use */
+								struct	sockaddr *rt_genmask;	/* for generation of cloned routes */
+									void	*rt_llinfo;		/* pointer to link level info cache */
+										void	(*rt_llinfo_free)(void *); /* link level info free function */
+											struct	rt_metrics rt_rmx;	/* metrics used by rx'ing protocols */
+												struct	rtentry *rt_gwroute;	/* implied entry for gatewayed routes */
+													struct	rtentry *rt_parent;	/* cloning parent of this route */
+														uint32_t generation_id;		/* route generation id */
+															/*
+															 * 	 * See bsd/net/route.c for synchronization notes.
+															 * 	 	 */
+															decl_lck_mtx_data(, rt_lock);	/* lock for routing entry */
+};
+#endif /* KERNEL_PRIVATE */
+
+#ifdef KERNEL_PRIVATE
+#define rt_use rt_rmx.rmx_pksent
+#endif /* KERNEL_PRIVATE */
+
+#define	RTF_UP		0x1		/* route usable */
+#define	RTF_GATEWAY	0x2		/* destination is a gateway */
+#define	RTF_HOST	0x4		/* host entry (net otherwise) */
+#define	RTF_REJECT	0x8		/* host or net unreachable */
+#define	RTF_DYNAMIC	0x10		/* created dynamically (by redirect) */
+#define	RTF_MODIFIED	0x20		/* modified dynamically (by redirect) */
+#define RTF_DONE	0x40		/* message confirmed */
+#define RTF_DELCLONE	0x80		/* delete cloned route */
+#define RTF_CLONING	0x100		/* generate new routes on use */
+#define RTF_XRESOLVE	0x200		/* external daemon resolves name */
+#define RTF_LLINFO	0x400		/* generated by link layer (e.g. ARP) */
+#define RTF_STATIC	0x800		/* manually added */
+#define RTF_BLACKHOLE	0x1000		/* just discard pkts (during updates) */
+#define RTF_PROTO2	0x4000		/* protocol specific routing flag */
+#define RTF_PROTO1	0x8000		/* protocol specific routing flag */
+
+#define RTF_PRCLONING	0x10000		/* protocol requires cloning */
+#define RTF_WASCLONED	0x20000		/* route generated through cloning */
+#define RTF_PROTO3	0x40000		/* protocol specific routing flag */
+					/* 0x80000 unused */
+#define RTF_PINNED	0x100000	/* future use */
+#define	RTF_LOCAL	0x200000	/* route represents a local address */
+#define	RTF_BROADCAST	0x400000	/* route represents a bcast address */
+#define	RTF_MULTICAST	0x800000	/* route represents a mcast address */
+#define RTF_IFSCOPE	0x1000000	/* has valid interface scope */
+#define RTF_CONDEMNED	0x2000000	/* defunct; no longer modifiable */
+					/* 0x4000000 and up unassigned */
+
+/*
+ *  * Routing statistics.
+ *   */
+struct	rtstat {
+		short	rts_badredirect;	/* bogus redirect calls */
+			short	rts_dynamic;		/* routes created by redirects */
+				short	rts_newgateway;		/* routes modified by redirects */
+					short	rts_unreach;		/* lookups which failed */
+						short	rts_wildcard;		/* lookups satisfied by a wildcard */
+};
+
+/*
+ *  * Structures for routing messages.
+ *   */
+struct rt_msghdr {
+		u_short	rtm_msglen;		/* to skip over non-understood messages */
+			u_char	rtm_version;		/* future binary compatibility */
+				u_char	rtm_type;		/* message type */
+					u_short	rtm_index;		/* index for associated ifp */
+						int	rtm_flags;		/* flags, incl. kern & message, e.g. DONE */
+							int	rtm_addrs;		/* bitmask identifying sockaddrs in msg */
+								pid_t	rtm_pid;		/* identify sender */
+									int	rtm_seq;		/* for sender to identify action */
+										int	rtm_errno;		/* why failed */
+											int	rtm_use;		/* from rtentry */
+												u_int32_t rtm_inits;		/* which metrics we are initializing */
+													struct rt_metrics rtm_rmx;	/* metrics themselves */
+};
+
+struct rt_msghdr2 {
+		u_short	rtm_msglen;		/* to skip over non-understood messages */
+			u_char	rtm_version;		/* future binary compatibility */
+				u_char	rtm_type;		/* message type */
+					u_short	rtm_index;		/* index for associated ifp */
+						int	rtm_flags;		/* flags, incl. kern & message, e.g. DONE */
+							int	rtm_addrs;		/* bitmask identifying sockaddrs in msg */
+								int32_t	rtm_refcnt;		/* reference count */
+									int	rtm_parentflags;	/* flags of the parent route */
+										int	rtm_reserved;		/* reserved field set to 0 */
+											int	rtm_use;		/* from rtentry */
+												u_int32_t rtm_inits;		/* which metrics we are initializing */
+													struct rt_metrics rtm_rmx;	/* metrics themselves */
+};
+
+
+#define RTM_VERSION	5	/* Up the ante and ignore older versions */
+
+/*
+ *  * Message types.
+ *   */
+#define RTM_ADD		0x1	/* Add Route */
+#define RTM_DELETE	0x2	/* Delete Route */
+#define RTM_CHANGE	0x3	/* Change Metrics or flags */
+#define RTM_GET		0x4	/* Report Metrics */
+#define RTM_LOSING	0x5	/* Kernel Suspects Partitioning */
+#define RTM_REDIRECT	0x6	/* Told to use different route */
+#define RTM_MISS	0x7	/* Lookup failed on this address */
+#define RTM_LOCK	0x8	/* fix specified metrics */
+#define RTM_OLDADD	0x9	/* caused by SIOCADDRT */
+#define RTM_OLDDEL	0xa	/* caused by SIOCDELRT */
+#define RTM_RESOLVE	0xb	/* req to resolve dst to LL addr */
+#define RTM_NEWADDR	0xc	/* address being added to iface */
+#define RTM_DELADDR	0xd	/* address being removed from iface */
+#define RTM_IFINFO	0xe	/* iface going up/down etc. */
+#define	RTM_NEWMADDR	0xf	/* mcast group membership being added to if */
+#define	RTM_DELMADDR	0x10	/* mcast group membership being deleted */
+#ifdef PRIVATE
+#define RTM_GET_SILENT	0x11
+#endif /* PRIVATE */
+#define RTM_IFINFO2	0x12	/* */
+#define RTM_NEWMADDR2	0x13	/* */
+#define RTM_GET2	0x14	/* */
+
+/*
+ *  * Bitmask values for rtm_inits and rmx_locks.
+ *   */
+#define RTV_MTU		0x1	/* init or lock _mtu */
+#define RTV_HOPCOUNT	0x2	/* init or lock _hopcount */
+#define RTV_EXPIRE	0x4	/* init or lock _expire */
+#define RTV_RPIPE	0x8	/* init or lock _recvpipe */
+#define RTV_SPIPE	0x10	/* init or lock _sendpipe */
+#define RTV_SSTHRESH	0x20	/* init or lock _ssthresh */
+#define RTV_RTT		0x40	/* init or lock _rtt */
+#define RTV_RTTVAR	0x80	/* init or lock _rttvar */
+
+/*
+ *  * Bitmask values for rtm_addrs.
+ *   */
+#define RTA_DST		0x1	/* destination sockaddr present */
+#define RTA_GATEWAY	0x2	/* gateway sockaddr present */
+#define RTA_NETMASK	0x4	/* netmask sockaddr present */
+#define RTA_GENMASK	0x8	/* cloning mask sockaddr present */
+#define RTA_IFP		0x10	/* interface name sockaddr present */
+#define RTA_IFA		0x20	/* interface addr sockaddr present */
+#define RTA_AUTHOR	0x40	/* sockaddr for author of redirect */
+#define RTA_BRD		0x80	/* for NEWADDR, broadcast or p-p dest addr */
+
+/*
+ *  * Index offsets for sockaddr array for alternate internal encoding.
+ *   */
+#define RTAX_DST	0	/* destination sockaddr present */
+#define RTAX_GATEWAY	1	/* gateway sockaddr present */
+#define RTAX_NETMASK	2	/* netmask sockaddr present */
+#define RTAX_GENMASK	3	/* cloning mask sockaddr present */
+#define RTAX_IFP	4	/* interface name sockaddr present */
+#define RTAX_IFA	5	/* interface addr sockaddr present */
+#define RTAX_AUTHOR	6	/* sockaddr for author of redirect */
+#define RTAX_BRD	7	/* for NEWADDR, broadcast or p-p dest addr */
+#define RTAX_MAX	8	/* size of array to allocate */
+
+struct rt_addrinfo {
+		int	rti_addrs;
+			struct	sockaddr *rti_info[RTAX_MAX];
+};
+
+struct route_cb {
+		int	ip_count;
+			int	ip6_count;
+				int	ipx_count;
+					int	ns_count;
+						int	iso_count;
+							int	any_count;
+};
+
+#ifdef PRIVATE
+/*
+ *  * For scoped routing; a zero interface scope value means nil/no scope.
+ *   */
+#define	IFSCOPE_NONE	0
+#endif /* PRIVATE */
+
+#ifdef KERNEL_PRIVATE
+/*
+ *  * Generic call trace used by some subsystems (e.g. route, ifaddr)
+ *   */
+#define	CTRACE_STACK_SIZE	8		/* depth of stack trace */
+#define	CTRACE_HIST_SIZE	4		/* refcnt history size */
+typedef struct ctrace {
+		void	*th;				/* thread ptr */
+			void	*pc[CTRACE_STACK_SIZE];		/* PC stack trace */
+} ctrace_t;
+
+extern void ctrace_record(ctrace_t *);
+
+#define	RT_LOCK_ASSERT_HELD(_rt)					\
+		lck_mtx_assert(&(_rt)->rt_lock, LCK_MTX_ASSERT_OWNED)
+
+#define	RT_LOCK_ASSERT_NOTHELD(_rt)					\
+		lck_mtx_assert(&(_rt)->rt_lock, LCK_MTX_ASSERT_NOTOWNED)
+
+#define	RT_LOCK(_rt) do {						\
+		if (!rte_debug)							\
+			lck_mtx_lock(&(_rt)->rt_lock);				\
+		else								\
+			rt_lock(_rt, FALSE);					\
+} while (0)
+
+#define	RT_LOCK_SPIN(_rt) do {						\
+		if (!rte_debug)							\
+			lck_mtx_lock_spin(&(_rt)->rt_lock);			\
+		else								\
+			rt_lock(_rt, TRUE);					\
+} while (0)
+
+#define	RT_CONVERT_LOCK(_rt) do {					\
+		RT_LOCK_ASSERT_HELD(_rt);					\
+		lck_mtx_convert_spin(&(_rt)->rt_lock);				\
+} while (0)
+
+#define	RT_UNLOCK(_rt) do {						\
+		if (!rte_debug)							\
+			lck_mtx_unlock(&(_rt)->rt_lock);			\
+		else								\
+			rt_unlock(_rt);						\
+} while (0)
+
+#define	RT_ADDREF_LOCKED(_rt) do {					\
+		if (!rte_debug) {						\
+					RT_LOCK_ASSERT_HELD(_rt);				\
+					if (++(_rt)->rt_refcnt == 0)				\
+						panic("RT_ADDREF(%p) bad refcnt\n", _rt);	\
+				} else {							\
+							rtref(_rt);						\
+						}								\
+} while (0)
+
+/*
+ *  * Spin variant mutex is used here; caller is responsible for
+ *   * converting any previously-held similar lock to full mutex.
+ *    */
+#define	RT_ADDREF(_rt) do {						\
+		RT_LOCK_SPIN(_rt);						\
+		RT_ADDREF_LOCKED(_rt);						\
+		RT_UNLOCK(_rt);							\
+} while (0)
+
+#define	RT_REMREF_LOCKED(_rt) do {					\
+		if (!rte_debug) {						\
+					RT_LOCK_ASSERT_HELD(_rt);				\
+					if ((_rt)->rt_refcnt == 0)				\
+						panic("RT_REMREF(%p) bad refcnt\n", _rt);	\
+					--(_rt)->rt_refcnt;					\
+				} else {							\
+							(void) rtunref(_rt);					\
+						}								\
+} while (0)
+
+/*
+ *  * Spin variant mutex is used here; caller is responsible for
+ *   * converting any previously-held similar lock to full mutex.
+ *    */
+#define	RT_REMREF(_rt) do {						\
+		RT_LOCK_SPIN(_rt);						\
+		RT_REMREF_LOCKED(_rt);						\
+		RT_UNLOCK(_rt);							\
+} while (0)
+
+#define RTFREE(_rt)		rtfree(_rt)
+#define RTFREE_LOCKED(_rt)	rtfree_locked(_rt)
+
+extern struct route_cb route_cb;
+extern struct radix_node_head *rt_tables[AF_MAX+1];
+__private_extern__ lck_mtx_t *rnh_lock;
+__private_extern__ int use_routegenid;
+__private_extern__ uint32_t route_generation;
+__private_extern__ int rttrash;
+__private_extern__ unsigned int rte_debug;
+
+struct ifmultiaddr;
+struct proc;
+
+extern void route_init(void) __attribute__((section("__TEXT, initcode")));
+extern void routegenid_update(void);
+extern void rt_ifmsg(struct ifnet *);
+extern void rt_missmsg(int, struct rt_addrinfo *, int, int);
+extern void rt_newaddrmsg(int, struct ifaddr *, int, struct rtentry *);
+extern void rt_newmaddrmsg(int, struct ifmultiaddr *);
+extern int rt_setgate(struct rtentry *, struct sockaddr *, struct sockaddr *);
+extern void set_primary_ifscope(unsigned int);
+extern unsigned int get_primary_ifscope(void);
+extern boolean_t rt_inet_default(struct rtentry *, struct sockaddr *);
+extern struct rtentry *rt_lookup(boolean_t, struct sockaddr *,
+		    struct sockaddr *, struct radix_node_head *, unsigned int);
+extern void rtalloc(struct route *);
+extern void rtalloc_ign(struct route *, uint32_t);
+extern void rtalloc_ign_locked(struct route *, uint32_t);
+extern void rtalloc_scoped_ign(struct route *, uint32_t, unsigned int);
+extern void rtalloc_scoped_ign_locked(struct route *, uint32_t, unsigned int);
+extern struct rtentry *rtalloc1(struct sockaddr *, int, uint32_t);
+extern struct rtentry *rtalloc1_locked(struct sockaddr *, int, uint32_t);
+extern struct rtentry *rtalloc1_scoped(struct sockaddr *, int, uint32_t,
+		    unsigned int);
+extern struct rtentry *rtalloc1_scoped_locked(struct sockaddr *, int,
+		    uint32_t, unsigned int);
+extern void rtfree(struct rtentry *);
+extern void rtfree_locked(struct rtentry *);
+extern void rtref(struct rtentry *);
+/*
+ *  * rtunref will decrement the refcount, rtfree will decrement and free if
+ *   * the refcount has reached zero and the route is not up.
+ *    * Unless you have good reason to do otherwise, use rtfree.
+ *     */
+extern int rtunref(struct rtentry *);
+extern void rtsetifa(struct rtentry *, struct ifaddr *);
+extern int rtinit(struct ifaddr *, int, int);
+extern int rtinit_locked(struct ifaddr *, int, int);
+extern int rtioctl(unsigned long, caddr_t, struct proc *);
+extern void rtredirect(struct ifnet *, struct sockaddr *, struct sockaddr *,
+		    struct sockaddr *, int, struct sockaddr *, struct rtentry **);
+extern int rtrequest(int, struct sockaddr *,
+		    struct sockaddr *, struct sockaddr *, int, struct rtentry **);
+extern int rtrequest_locked(int, struct sockaddr *,
+		    struct sockaddr *, struct sockaddr *, int, struct rtentry **);
+extern int rtrequest_scoped_locked(int, struct sockaddr *, struct sockaddr *,
+		    struct sockaddr *, int, struct rtentry **, unsigned int);
+extern unsigned int sa_get_ifscope(struct sockaddr *);
+extern void rt_lock(struct rtentry *, boolean_t);
+extern void rt_unlock(struct rtentry *);
+extern struct sockaddr *rtm_scrub_ifscope(int, struct sockaddr *,
+		    struct sockaddr *, struct sockaddr_storage *);
+#endif /* KERNEL_PRIVATE */
+
+#endif

--- a/ios/route.h
+++ b/ios/route.h
@@ -1,65 +1,65 @@
 /*
- *  * Copyright (c) 2000-2008 Apple Inc. All rights reserved.
- *   *
- *    * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
- *     * 
- *      * This file contains Original Code and/or Modifications of Original Code
- *       * as defined in and that are subject to the Apple Public Source License
- *        * Version 2.0 (the 'License'). You may not use this file except in
- *         * compliance with the License. The rights granted to you under the License
- *          * may not be used to create, or enable the creation or redistribution of,
- *           * unlawful or unlicensed copies of an Apple operating system, or to
- *            * circumvent, violate, or enable the circumvention or violation of, any
- *             * terms of an Apple operating system software license agreement.
- *              * 
- *               * Please obtain a copy of the License at
- *                * http://www.opensource.apple.com/apsl/ and read it before using this file.
- *                 * 
- *                  * The Original Code and all software distributed under the License are
- *                   * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
- *                    * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
- *                     * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
- *                      * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
- *                       * Please see the License for the specific language governing rights and
- *                        * limitations under the License.
- *                         * 
- *                          * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
- *                           */
+ * Copyright (c) 2000-2008 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
 /*
- *  * Copyright (c) 1980, 1986, 1993
- *   *	The Regents of the University of California.  All rights reserved.
- *    *
- *     * Redistribution and use in source and binary forms, with or without
- *      * modification, are permitted provided that the following conditions
- *       * are met:
- *        * 1. Redistributions of source code must retain the above copyright
- *         *    notice, this list of conditions and the following disclaimer.
- *          * 2. Redistributions in binary form must reproduce the above copyright
- *           *    notice, this list of conditions and the following disclaimer in the
- *            *    documentation and/or other materials provided with the distribution.
- *             * 3. All advertising materials mentioning features or use of this software
- *              *    must display the following acknowledgement:
- *               *	This product includes software developed by the University of
- *                *	California, Berkeley and its contributors.
- *                 * 4. Neither the name of the University nor the names of its contributors
- *                  *    may be used to endorse or promote products derived from this software
- *                   *    without specific prior written permission.
- *                    *
- *                     * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
- *                      * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- *                       * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- *                        * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
- *                         * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- *                          * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- *                           * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- *                            * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *                             * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- *                              * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- *                               * SUCH DAMAGE.
- *                                *
- *                                 *	@(#)route.h	8.3 (Berkeley) 4/19/94
- *                                  * $FreeBSD: src/sys/net/route.h,v 1.36.2.1 2000/08/16 06:14:23 jayanth Exp $
- *                                   */
+ * Copyright (c) 1980, 1986, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)route.h	8.3 (Berkeley) 4/19/94
+ * $FreeBSD: src/sys/net/route.h,v 1.36.2.1 2000/08/16 06:14:23 jayanth Exp $
+ */
 
 #ifndef _NET_ROUTE_H_
 #define _NET_ROUTE_H_
@@ -69,28 +69,28 @@
 #include <sys/socket.h>
 
 /*
- *  * Kernel resident routing tables.
- *   *
- *    * The routing tables are initialized when interface addresses
- *     * are set by making entries for all directly connected interfaces.
- *      */
+ * Kernel resident routing tables.
+ *
+ * The routing tables are initialized when interface addresses
+ * are set by making entries for all directly connected interfaces.
+ */
 
 /*
- *  * A route consists of a destination address and a reference
- *   * to a routing entry.  These are often held by protocols
- *    * in their control blocks, e.g. inpcb.
- *     */
+ * A route consists of a destination address and a reference
+ * to a routing entry.  These are often held by protocols
+ * in their control blocks, e.g. inpcb.
+ */
 #ifdef PRIVATE
 struct  rtentry;
 struct route {
-		/*
-		 * 	 * N.B: struct route must begin with ro_rt and ro_flags
-		 * 	 	 * because the code does some casts of a 'struct route_in6 *'
-		 * 	 	 	 * to a 'struct route *'.
-		 * 	 	 	 	 */
-		struct rtentry	*ro_rt;
-			uint32_t	ro_flags;	/* route flags (see below) */
-				struct sockaddr	ro_dst;
+	/*
+	 * N.B: struct route must begin with ro_rt and ro_flags
+	 * because the code does some casts of a 'struct route_in6 *'
+	 * to a 'struct route *'.
+	 */
+	struct rtentry	*ro_rt;
+	uint32_t	ro_flags;	/* route flags (see below) */
+	struct sockaddr	ro_dst;
 };
 
 #define	ROF_SRCIF_SELECTED	0x1 /* source interface was selected */
@@ -100,64 +100,64 @@ struct route;
 #endif /* PRIVATE */
 
 /*
- *  * These numbers are used by reliable protocols for determining
- *   * retransmission behavior and are included in the routing structure.
- *    */
+ * These numbers are used by reliable protocols for determining
+ * retransmission behavior and are included in the routing structure.
+ */
 struct rt_metrics {
-		u_int32_t	rmx_locks;	/* Kernel must leave these values alone */
-			u_int32_t	rmx_mtu;	/* MTU for this path */
-				u_int32_t	rmx_hopcount;	/* max hops expected */
-					int32_t		rmx_expire;	/* lifetime for route, e.g. redirect */
-						u_int32_t	rmx_recvpipe;	/* inbound delay-bandwidth product */
-							u_int32_t	rmx_sendpipe;	/* outbound delay-bandwidth product */
-								u_int32_t	rmx_ssthresh;	/* outbound gateway buffer limit */
-									u_int32_t	rmx_rtt;	/* estimated round trip time */
-										u_int32_t	rmx_rttvar;	/* estimated rtt variance */
-											u_int32_t	rmx_pksent;	/* packets sent using this route */
-												u_int32_t	rmx_filler[4];	/* will be used for T/TCP later */
+	u_int32_t	rmx_locks;	/* Kernel must leave these values alone */
+	u_int32_t	rmx_mtu;	/* MTU for this path */
+	u_int32_t	rmx_hopcount;	/* max hops expected */
+	int32_t		rmx_expire;	/* lifetime for route, e.g. redirect */
+	u_int32_t	rmx_recvpipe;	/* inbound delay-bandwidth product */
+	u_int32_t	rmx_sendpipe;	/* outbound delay-bandwidth product */
+	u_int32_t	rmx_ssthresh;	/* outbound gateway buffer limit */
+	u_int32_t	rmx_rtt;	/* estimated round trip time */
+	u_int32_t	rmx_rttvar;	/* estimated rtt variance */
+	u_int32_t	rmx_pksent;	/* packets sent using this route */
+	u_int32_t	rmx_filler[4];	/* will be used for T/TCP later */
 };
 
 /*
- *  * rmx_rtt and rmx_rttvar are stored as microseconds;
- *   */
+ * rmx_rtt and rmx_rttvar are stored as microseconds;
+ */
 #define	RTM_RTTUNIT	1000000	/* units for rtt, rttvar, as units per sec */
 
 /*
- *  * We distinguish between routes to hosts and routes to networks,
- *   * preferring the former if available.  For each route we infer
- *    * the interface to use from the gateway address supplied when
- *     * the route was entered.  Routes that forward packets through
- *      * gateways are marked so that the output routines know to address the
- *       * gateway rather than the ultimate destination.
- *        */
+ * We distinguish between routes to hosts and routes to networks,
+ * preferring the former if available.  For each route we infer
+ * the interface to use from the gateway address supplied when
+ * the route was entered.  Routes that forward packets through
+ * gateways are marked so that the output routines know to address the
+ * gateway rather than the ultimate destination.
+ */
 #ifdef KERNEL_PRIVATE
 #include <kern/locks.h>
 #ifndef RNF_NORMAL
 #include <net/radix.h>
 #endif
 /*
- *  * Kernel routing entry structure (private).
- *   */
+ * Kernel routing entry structure (private).
+ */
 struct rtentry {
-		struct	radix_node rt_nodes[2];	/* tree glue, and other values */
+	struct	radix_node rt_nodes[2];	/* tree glue, and other values */
 #define	rt_key(r)	((struct sockaddr *)((r)->rt_nodes->rn_key))
 #define	rt_mask(r)	((struct sockaddr *)((r)->rt_nodes->rn_mask))
-			struct	sockaddr *rt_gateway;	/* value */
-				int32_t	rt_refcnt;		/* # held references */
-					uint32_t rt_flags;		/* up/down?, host/net */
-						struct	ifnet *rt_ifp;		/* the answer: interface to use */
-							struct	ifaddr *rt_ifa;		/* the answer: interface addr to use */
-								struct	sockaddr *rt_genmask;	/* for generation of cloned routes */
-									void	*rt_llinfo;		/* pointer to link level info cache */
-										void	(*rt_llinfo_free)(void *); /* link level info free function */
-											struct	rt_metrics rt_rmx;	/* metrics used by rx'ing protocols */
-												struct	rtentry *rt_gwroute;	/* implied entry for gatewayed routes */
-													struct	rtentry *rt_parent;	/* cloning parent of this route */
-														uint32_t generation_id;		/* route generation id */
-															/*
-															 * 	 * See bsd/net/route.c for synchronization notes.
-															 * 	 	 */
-															decl_lck_mtx_data(, rt_lock);	/* lock for routing entry */
+	struct	sockaddr *rt_gateway;	/* value */
+	int32_t	rt_refcnt;		/* # held references */
+	uint32_t rt_flags;		/* up/down?, host/net */
+	struct	ifnet *rt_ifp;		/* the answer: interface to use */
+	struct	ifaddr *rt_ifa;		/* the answer: interface addr to use */
+	struct	sockaddr *rt_genmask;	/* for generation of cloned routes */
+	void	*rt_llinfo;		/* pointer to link level info cache */
+	void	(*rt_llinfo_free)(void *); /* link level info free function */
+	struct	rt_metrics rt_rmx;	/* metrics used by rx'ing protocols */
+	struct	rtentry *rt_gwroute;	/* implied entry for gatewayed routes */
+	struct	rtentry *rt_parent;	/* cloning parent of this route */
+	uint32_t generation_id;		/* route generation id */
+	/*
+	 * See bsd/net/route.c for synchronization notes.
+	 */
+	decl_lck_mtx_data(, rt_lock);	/* lock for routing entry */
 };
 #endif /* KERNEL_PRIVATE */
 
@@ -194,55 +194,55 @@ struct rtentry {
 					/* 0x4000000 and up unassigned */
 
 /*
- *  * Routing statistics.
- *   */
+ * Routing statistics.
+ */
 struct	rtstat {
-		short	rts_badredirect;	/* bogus redirect calls */
-			short	rts_dynamic;		/* routes created by redirects */
-				short	rts_newgateway;		/* routes modified by redirects */
-					short	rts_unreach;		/* lookups which failed */
-						short	rts_wildcard;		/* lookups satisfied by a wildcard */
+	short	rts_badredirect;	/* bogus redirect calls */
+	short	rts_dynamic;		/* routes created by redirects */
+	short	rts_newgateway;		/* routes modified by redirects */
+	short	rts_unreach;		/* lookups which failed */
+	short	rts_wildcard;		/* lookups satisfied by a wildcard */
 };
 
 /*
- *  * Structures for routing messages.
- *   */
+ * Structures for routing messages.
+ */
 struct rt_msghdr {
-		u_short	rtm_msglen;		/* to skip over non-understood messages */
-			u_char	rtm_version;		/* future binary compatibility */
-				u_char	rtm_type;		/* message type */
-					u_short	rtm_index;		/* index for associated ifp */
-						int	rtm_flags;		/* flags, incl. kern & message, e.g. DONE */
-							int	rtm_addrs;		/* bitmask identifying sockaddrs in msg */
-								pid_t	rtm_pid;		/* identify sender */
-									int	rtm_seq;		/* for sender to identify action */
-										int	rtm_errno;		/* why failed */
-											int	rtm_use;		/* from rtentry */
-												u_int32_t rtm_inits;		/* which metrics we are initializing */
-													struct rt_metrics rtm_rmx;	/* metrics themselves */
+	u_short	rtm_msglen;		/* to skip over non-understood messages */
+	u_char	rtm_version;		/* future binary compatibility */
+	u_char	rtm_type;		/* message type */
+	u_short	rtm_index;		/* index for associated ifp */
+	int	rtm_flags;		/* flags, incl. kern & message, e.g. DONE */
+	int	rtm_addrs;		/* bitmask identifying sockaddrs in msg */
+	pid_t	rtm_pid;		/* identify sender */
+	int	rtm_seq;		/* for sender to identify action */
+	int	rtm_errno;		/* why failed */
+	int	rtm_use;		/* from rtentry */
+	u_int32_t rtm_inits;		/* which metrics we are initializing */
+	struct rt_metrics rtm_rmx;	/* metrics themselves */
 };
 
 struct rt_msghdr2 {
-		u_short	rtm_msglen;		/* to skip over non-understood messages */
-			u_char	rtm_version;		/* future binary compatibility */
-				u_char	rtm_type;		/* message type */
-					u_short	rtm_index;		/* index for associated ifp */
-						int	rtm_flags;		/* flags, incl. kern & message, e.g. DONE */
-							int	rtm_addrs;		/* bitmask identifying sockaddrs in msg */
-								int32_t	rtm_refcnt;		/* reference count */
-									int	rtm_parentflags;	/* flags of the parent route */
-										int	rtm_reserved;		/* reserved field set to 0 */
-											int	rtm_use;		/* from rtentry */
-												u_int32_t rtm_inits;		/* which metrics we are initializing */
-													struct rt_metrics rtm_rmx;	/* metrics themselves */
+	u_short	rtm_msglen;		/* to skip over non-understood messages */
+	u_char	rtm_version;		/* future binary compatibility */
+	u_char	rtm_type;		/* message type */
+	u_short	rtm_index;		/* index for associated ifp */
+	int	rtm_flags;		/* flags, incl. kern & message, e.g. DONE */
+	int	rtm_addrs;		/* bitmask identifying sockaddrs in msg */
+	int32_t	rtm_refcnt;		/* reference count */
+	int	rtm_parentflags;	/* flags of the parent route */
+	int	rtm_reserved;		/* reserved field set to 0 */
+	int	rtm_use;		/* from rtentry */
+	u_int32_t rtm_inits;		/* which metrics we are initializing */
+	struct rt_metrics rtm_rmx;	/* metrics themselves */
 };
 
 
 #define RTM_VERSION	5	/* Up the ante and ignore older versions */
 
 /*
- *  * Message types.
- *   */
+ * Message types.
+ */
 #define RTM_ADD		0x1	/* Add Route */
 #define RTM_DELETE	0x2	/* Delete Route */
 #define RTM_CHANGE	0x3	/* Change Metrics or flags */
@@ -267,8 +267,8 @@ struct rt_msghdr2 {
 #define RTM_GET2	0x14	/* */
 
 /*
- *  * Bitmask values for rtm_inits and rmx_locks.
- *   */
+ * Bitmask values for rtm_inits and rmx_locks.
+ */
 #define RTV_MTU		0x1	/* init or lock _mtu */
 #define RTV_HOPCOUNT	0x2	/* init or lock _hopcount */
 #define RTV_EXPIRE	0x4	/* init or lock _expire */
@@ -279,8 +279,8 @@ struct rt_msghdr2 {
 #define RTV_RTTVAR	0x80	/* init or lock _rttvar */
 
 /*
- *  * Bitmask values for rtm_addrs.
- *   */
+ * Bitmask values for rtm_addrs.
+ */
 #define RTA_DST		0x1	/* destination sockaddr present */
 #define RTA_GATEWAY	0x2	/* gateway sockaddr present */
 #define RTA_NETMASK	0x4	/* netmask sockaddr present */
@@ -291,8 +291,8 @@ struct rt_msghdr2 {
 #define RTA_BRD		0x80	/* for NEWADDR, broadcast or p-p dest addr */
 
 /*
- *  * Index offsets for sockaddr array for alternate internal encoding.
- *   */
+ * Index offsets for sockaddr array for alternate internal encoding.
+ */
 #define RTAX_DST	0	/* destination sockaddr present */
 #define RTAX_GATEWAY	1	/* gateway sockaddr present */
 #define RTAX_NETMASK	2	/* netmask sockaddr present */
@@ -304,110 +304,110 @@ struct rt_msghdr2 {
 #define RTAX_MAX	8	/* size of array to allocate */
 
 struct rt_addrinfo {
-		int	rti_addrs;
-			struct	sockaddr *rti_info[RTAX_MAX];
+	int	rti_addrs;
+	struct	sockaddr *rti_info[RTAX_MAX];
 };
 
 struct route_cb {
-		int	ip_count;
-			int	ip6_count;
-				int	ipx_count;
-					int	ns_count;
-						int	iso_count;
-							int	any_count;
+	int	ip_count;
+	int	ip6_count;
+	int	ipx_count;
+	int	ns_count;
+	int	iso_count;
+	int	any_count;
 };
 
 #ifdef PRIVATE
 /*
- *  * For scoped routing; a zero interface scope value means nil/no scope.
- *   */
+ * For scoped routing; a zero interface scope value means nil/no scope.
+ */
 #define	IFSCOPE_NONE	0
 #endif /* PRIVATE */
 
 #ifdef KERNEL_PRIVATE
 /*
- *  * Generic call trace used by some subsystems (e.g. route, ifaddr)
- *   */
+ * Generic call trace used by some subsystems (e.g. route, ifaddr)
+ */
 #define	CTRACE_STACK_SIZE	8		/* depth of stack trace */
 #define	CTRACE_HIST_SIZE	4		/* refcnt history size */
 typedef struct ctrace {
-		void	*th;				/* thread ptr */
-			void	*pc[CTRACE_STACK_SIZE];		/* PC stack trace */
+	void	*th;				/* thread ptr */
+	void	*pc[CTRACE_STACK_SIZE];		/* PC stack trace */
 } ctrace_t;
 
 extern void ctrace_record(ctrace_t *);
 
 #define	RT_LOCK_ASSERT_HELD(_rt)					\
-		lck_mtx_assert(&(_rt)->rt_lock, LCK_MTX_ASSERT_OWNED)
+	lck_mtx_assert(&(_rt)->rt_lock, LCK_MTX_ASSERT_OWNED)
 
 #define	RT_LOCK_ASSERT_NOTHELD(_rt)					\
-		lck_mtx_assert(&(_rt)->rt_lock, LCK_MTX_ASSERT_NOTOWNED)
+	lck_mtx_assert(&(_rt)->rt_lock, LCK_MTX_ASSERT_NOTOWNED)
 
 #define	RT_LOCK(_rt) do {						\
-		if (!rte_debug)							\
-			lck_mtx_lock(&(_rt)->rt_lock);				\
-		else								\
-			rt_lock(_rt, FALSE);					\
+	if (!rte_debug)							\
+		lck_mtx_lock(&(_rt)->rt_lock);				\
+	else								\
+		rt_lock(_rt, FALSE);					\
 } while (0)
 
 #define	RT_LOCK_SPIN(_rt) do {						\
-		if (!rte_debug)							\
-			lck_mtx_lock_spin(&(_rt)->rt_lock);			\
-		else								\
-			rt_lock(_rt, TRUE);					\
+	if (!rte_debug)							\
+		lck_mtx_lock_spin(&(_rt)->rt_lock);			\
+	else								\
+		rt_lock(_rt, TRUE);					\
 } while (0)
 
 #define	RT_CONVERT_LOCK(_rt) do {					\
-		RT_LOCK_ASSERT_HELD(_rt);					\
-		lck_mtx_convert_spin(&(_rt)->rt_lock);				\
+	RT_LOCK_ASSERT_HELD(_rt);					\
+	lck_mtx_convert_spin(&(_rt)->rt_lock);				\
 } while (0)
 
 #define	RT_UNLOCK(_rt) do {						\
-		if (!rte_debug)							\
-			lck_mtx_unlock(&(_rt)->rt_lock);			\
-		else								\
-			rt_unlock(_rt);						\
+	if (!rte_debug)							\
+		lck_mtx_unlock(&(_rt)->rt_lock);			\
+	else								\
+		rt_unlock(_rt);						\
 } while (0)
 
 #define	RT_ADDREF_LOCKED(_rt) do {					\
-		if (!rte_debug) {						\
-					RT_LOCK_ASSERT_HELD(_rt);				\
-					if (++(_rt)->rt_refcnt == 0)				\
-						panic("RT_ADDREF(%p) bad refcnt\n", _rt);	\
-				} else {							\
-							rtref(_rt);						\
-						}								\
+	if (!rte_debug) {						\
+		RT_LOCK_ASSERT_HELD(_rt);				\
+		if (++(_rt)->rt_refcnt == 0)				\
+			panic("RT_ADDREF(%p) bad refcnt\n", _rt);	\
+	} else {							\
+		rtref(_rt);						\
+	}								\
 } while (0)
 
 /*
- *  * Spin variant mutex is used here; caller is responsible for
- *   * converting any previously-held similar lock to full mutex.
- *    */
+ * Spin variant mutex is used here; caller is responsible for
+ * converting any previously-held similar lock to full mutex.
+ */
 #define	RT_ADDREF(_rt) do {						\
-		RT_LOCK_SPIN(_rt);						\
-		RT_ADDREF_LOCKED(_rt);						\
-		RT_UNLOCK(_rt);							\
+	RT_LOCK_SPIN(_rt);						\
+	RT_ADDREF_LOCKED(_rt);						\
+	RT_UNLOCK(_rt);							\
 } while (0)
 
 #define	RT_REMREF_LOCKED(_rt) do {					\
-		if (!rte_debug) {						\
-					RT_LOCK_ASSERT_HELD(_rt);				\
-					if ((_rt)->rt_refcnt == 0)				\
-						panic("RT_REMREF(%p) bad refcnt\n", _rt);	\
-					--(_rt)->rt_refcnt;					\
-				} else {							\
-							(void) rtunref(_rt);					\
-						}								\
+	if (!rte_debug) {						\
+		RT_LOCK_ASSERT_HELD(_rt);				\
+		if ((_rt)->rt_refcnt == 0)				\
+			panic("RT_REMREF(%p) bad refcnt\n", _rt);	\
+		--(_rt)->rt_refcnt;					\
+	} else {							\
+		(void) rtunref(_rt);					\
+	}								\
 } while (0)
 
 /*
- *  * Spin variant mutex is used here; caller is responsible for
- *   * converting any previously-held similar lock to full mutex.
- *    */
+ * Spin variant mutex is used here; caller is responsible for
+ * converting any previously-held similar lock to full mutex.
+ */
 #define	RT_REMREF(_rt) do {						\
-		RT_LOCK_SPIN(_rt);						\
-		RT_REMREF_LOCKED(_rt);						\
-		RT_UNLOCK(_rt);							\
+	RT_LOCK_SPIN(_rt);						\
+	RT_REMREF_LOCKED(_rt);						\
+	RT_UNLOCK(_rt);							\
 } while (0)
 
 #define RTFREE(_rt)		rtfree(_rt)
@@ -435,7 +435,7 @@ extern void set_primary_ifscope(unsigned int);
 extern unsigned int get_primary_ifscope(void);
 extern boolean_t rt_inet_default(struct rtentry *, struct sockaddr *);
 extern struct rtentry *rt_lookup(boolean_t, struct sockaddr *,
-		    struct sockaddr *, struct radix_node_head *, unsigned int);
+    struct sockaddr *, struct radix_node_head *, unsigned int);
 extern void rtalloc(struct route *);
 extern void rtalloc_ign(struct route *, uint32_t);
 extern void rtalloc_ign_locked(struct route *, uint32_t);
@@ -444,35 +444,35 @@ extern void rtalloc_scoped_ign_locked(struct route *, uint32_t, unsigned int);
 extern struct rtentry *rtalloc1(struct sockaddr *, int, uint32_t);
 extern struct rtentry *rtalloc1_locked(struct sockaddr *, int, uint32_t);
 extern struct rtentry *rtalloc1_scoped(struct sockaddr *, int, uint32_t,
-		    unsigned int);
+    unsigned int);
 extern struct rtentry *rtalloc1_scoped_locked(struct sockaddr *, int,
-		    uint32_t, unsigned int);
+    uint32_t, unsigned int);
 extern void rtfree(struct rtentry *);
 extern void rtfree_locked(struct rtentry *);
 extern void rtref(struct rtentry *);
 /*
- *  * rtunref will decrement the refcount, rtfree will decrement and free if
- *   * the refcount has reached zero and the route is not up.
- *    * Unless you have good reason to do otherwise, use rtfree.
- *     */
+ * rtunref will decrement the refcount, rtfree will decrement and free if
+ * the refcount has reached zero and the route is not up.
+ * Unless you have good reason to do otherwise, use rtfree.
+ */
 extern int rtunref(struct rtentry *);
 extern void rtsetifa(struct rtentry *, struct ifaddr *);
 extern int rtinit(struct ifaddr *, int, int);
 extern int rtinit_locked(struct ifaddr *, int, int);
 extern int rtioctl(unsigned long, caddr_t, struct proc *);
 extern void rtredirect(struct ifnet *, struct sockaddr *, struct sockaddr *,
-		    struct sockaddr *, int, struct sockaddr *, struct rtentry **);
+    struct sockaddr *, int, struct sockaddr *, struct rtentry **);
 extern int rtrequest(int, struct sockaddr *,
-		    struct sockaddr *, struct sockaddr *, int, struct rtentry **);
+    struct sockaddr *, struct sockaddr *, int, struct rtentry **);
 extern int rtrequest_locked(int, struct sockaddr *,
-		    struct sockaddr *, struct sockaddr *, int, struct rtentry **);
+    struct sockaddr *, struct sockaddr *, int, struct rtentry **);
 extern int rtrequest_scoped_locked(int, struct sockaddr *, struct sockaddr *,
-		    struct sockaddr *, int, struct rtentry **, unsigned int);
+    struct sockaddr *, int, struct rtentry **, unsigned int);
 extern unsigned int sa_get_ifscope(struct sockaddr *);
 extern void rt_lock(struct rtentry *, boolean_t);
 extern void rt_unlock(struct rtentry *);
 extern struct sockaddr *rtm_scrub_ifscope(int, struct sockaddr *,
-		    struct sockaddr *, struct sockaddr_storage *);
+    struct sockaddr *, struct sockaddr_storage *);
 #endif /* KERNEL_PRIVATE */
 
 #endif


### PR DESCRIPTION
Enable fetching the default gateway of the Wi-Fi connection on iOS and Android.

~**Note:** Android version has been tested (Nexus 6P w/ 8.1.0), but iOS version is totally untested.~
**Update:**
Tested on:
- Nexus 6P w/ Android 8.1.0
- iPhone 8 w/ iOS 12.0